### PR TITLE
fix: ensure Homebrew is in PATH after installation

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -20,6 +20,4 @@ jobs:
 
       - name: Test - chezmoi
         run: |
-          exec zsh -c '
-            chezmoi doctor && mise doctor
-          '
+          zsh -c 'source ~/.zshrc && chezmoi doctor && mise doctor'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,12 +12,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Install and setup
-        run: sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply shomatan
+      - name: Install chezmoi
+        run: |
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b ~/.local/bin
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Setup chezmoi
+        run: chezmoi init --apply shomatan
 
       - name: Test - .zshrc
         run: cat ~/.zshrc
 
-      - name: Test - chezmoi
+      - name: Test - chezmoi and mise
         run: |
+          export PATH="$HOME/.local/bin:$PATH"
           zsh -c 'source ~/.zshrc && chezmoi doctor && mise doctor'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,30 +15,38 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - uses: Vampire/setup-wsl@v6
+      - name: Setup WSL
+        uses: Vampire/setup-wsl@v3
         with:
-          additional-packages: curl ca-certificates openssl zsh git
-          use-cache: "false"
+          distribution: Ubuntu-22.04
+          additional-packages:
+            curl
+            ca-certificates
+            git
+            zsh
 
       - name: System setup
         run: |
           sudo apt-get update
-          sudo apt-get install -y zsh git
+          sudo apt-get install -y curl git zsh
 
       - name: Install chezmoi
         run: |
-          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b ~/.local/bin
+          export PATH="$HOME/.local/bin:$PATH"
           which chezmoi
 
       - name: Setup chezmoi
         run: |
+          export PATH="$HOME/.local/bin:$PATH"
           chezmoi init --apply shomatan
 
       - name: Verify installation
         run: |
+          export PATH="$HOME/.local/bin:$PATH"
           echo "Testing chezmoi..."
           chezmoi --version
           chezmoi doctor
-          
+
           echo "Testing mise..."
-          ~/.local/bin/mise --version
+          mise --version

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -104,14 +104,19 @@ bindkey '^R' history-incremental-pattern-search-backward
 # Homebrew
 # -----------------------------------------------------------------------------
 if [[ -f "/opt/homebrew/bin/brew" ]]; then
+    # Apple Silicon Mac
     eval $(/opt/homebrew/bin/brew shellenv)
+elif [[ -f "/usr/local/bin/brew" ]]; then
+    # Intel Mac
+    eval $(/usr/local/bin/brew shellenv)
 fi
 
 
 # mise
 # -----------------------------------------------------------------------------
-
-eval "$(mise activate zsh)"
+if command -v mise &> /dev/null; then
+    eval "$(mise activate zsh)"
+fi
 
 
 # zinit

--- a/run_after_10-brew-upgrade.sh.tmpl
+++ b/run_after_10-brew-upgrade.sh.tmpl
@@ -2,6 +2,22 @@
 
 # Check if we're on macOS
 if [[ "$OSTYPE" == "darwin"* ]]; then
-    echo "Running brew upgrade..."
-    brew upgrade
+    # Ensure Homebrew is in PATH
+    if ! command -v brew &> /dev/null; then
+        if [ -f /opt/homebrew/bin/brew ]; then
+            # Apple Silicon Mac
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+        elif [ -f /usr/local/bin/brew ]; then
+            # Intel Mac
+            eval "$(/usr/local/bin/brew shellenv)"
+        fi
+    fi
+
+    # Run brew upgrade if brew is available
+    if command -v brew &> /dev/null; then
+        echo "Running brew upgrade..."
+        brew upgrade
+    else
+        echo "Warning: Homebrew is not installed or not found"
+    fi
 fi 

--- a/run_once_5-install-packages.sh.tmpl
+++ b/run_once_5-install-packages.sh.tmpl
@@ -2,7 +2,23 @@
 
 # Install Homebrew
 {{ if eq .chezmoi.os "darwin" }}
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+if ! command -v brew &> /dev/null; then
+    echo "Installing Homebrew..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    # Add Homebrew to PATH immediately after installation
+    if [ -f /opt/homebrew/bin/brew ]; then
+        # Apple Silicon Mac
+        echo "Adding Homebrew (Apple Silicon) to PATH..."
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [ -f /usr/local/bin/brew ]; then
+        # Intel Mac
+        echo "Adding Homebrew (Intel) to PATH..."
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
+else
+    echo "Homebrew is already installed"
+fi
 {{ end }}
 
 # Install mise
@@ -11,7 +27,12 @@ sudo apt install -y curl git
 curl https://mise.run | sh
 {{ end }}
 {{ if eq .chezmoi.os "darwin" }}
-brew install mise
+if ! command -v mise &> /dev/null; then
+    echo "Installing mise via Homebrew..."
+    brew install mise
+else
+    echo "mise is already installed"
+fi
 {{ end }}
 
 # Install zsh


### PR DESCRIPTION
This fixes an issue where `brew` command was not found immediately after Homebrew installation during `chezmoi init`. The fix includes:

- Add PATH setup immediately after Homebrew installation using `brew shellenv`
- Support both Apple Silicon (/opt/homebrew) and Intel (/usr/local) Macs
- Add idempotency checks to avoid reinstalling already installed packages
- Add PATH setup in brew upgrade script as well for consistency

The issue occurred because Homebrew's installation script doesn't automatically add the brew binary to the current shell's PATH, causing subsequent `brew install mise` commands to fail.