### PR TITLE
Fix Neovim directory permission error

### DIFF
--- a/.chezmoiremove
+++ b/.chezmoiremove
@@ -1,0 +1,2 @@
+# Remove old nvim init.vim that was replaced by init.lua (LazyVim)
+.config/nvim/init.vim

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ chezmoi diff
    - `dot_p10k.zsh`: Powerlevel10kテーマ設定
 
 2. **エディタ設定**
-   - `dot_config/nvim/init.vim`: Neovim設定
+   - `dot_config/nvim/`: LazyVimベースのNeovim設定（`init.lua`）
    - `dot_ideavimrc`: JetBrains IDE用のIdeaVim設定
    - `private_Library/private_Application Support/private_Cursor/User/`: Cursorエディタ設定
 


### PR DESCRIPTION
LazyVimへの移行後もinit.vimが残っていたため、
chezmoi applyで設定競合が発生していた問題を修正。

- .chezmoiremoveを追加してinit.vimを削除対象に
- CLAUDE.mdのドキュメントを更新