### PR TITLE
Research Neovim and LazyVim Brew installation requirements

### DIFF
--- a/run_once_5-install-packages.sh.tmpl
+++ b/run_once_5-install-packages.sh.tmpl
@@ -25,6 +25,33 @@ fi
 {{ if eq .chezmoi.os "linux" }}
 sudo apt install -y curl git
 curl https://mise.run | sh
+
+# Install Neovim and LazyVim dependencies
+echo "Installing Neovim and LazyVim dependencies..."
+
+# Add Neovim PPA for latest version
+sudo apt install -y software-properties-common
+sudo add-apt-repository -y ppa:neovim-ppa/stable
+sudo apt update
+
+# Install packages
+sudo apt install -y neovim ripgrep fd-find luarocks build-essential nodejs npm unzip
+
+# Install lazygit from GitHub releases
+echo "Installing lazygit..."
+LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": "v\K[^"]*')
+curl -Lo /tmp/lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz"
+tar xf /tmp/lazygit.tar.gz -C /tmp lazygit
+sudo install /tmp/lazygit /usr/local/bin
+rm /tmp/lazygit /tmp/lazygit.tar.gz
+
+# Install Hack Nerd Font
+echo "Installing Hack Nerd Font..."
+mkdir -p ~/.local/share/fonts
+curl -fLo /tmp/Hack.zip https://github.com/ryanoasis/nerd-fonts/releases/latest/download/Hack.zip
+unzip -o /tmp/Hack.zip -d ~/.local/share/fonts
+rm /tmp/Hack.zip
+fc-cache -fv
 {{ end }}
 {{ if eq .chezmoi.os "darwin" }}
 if ! command -v mise &> /dev/null; then
@@ -33,6 +60,14 @@ if ! command -v mise &> /dev/null; then
 else
     echo "mise is already installed"
 fi
+
+# Install Neovim and LazyVim dependencies
+echo "Installing Neovim and LazyVim dependencies..."
+brew install neovim ripgrep fd lazygit luarocks gcc node
+
+# Install Nerd Font
+echo "Installing Hack Nerd Font..."
+brew install --cask font-hack-nerd-font
 {{ end }}
 
 # Install zsh


### PR DESCRIPTION
- macOS: brew install neovim, ripgrep, fd, lazygit, luarocks, gcc, node
- macOS: brew install --cask font-hack-nerd-font
- Linux: add neovim-ppa/stable for latest neovim
- Linux: apt install neovim, ripgrep, fd-find, luarocks, build-essential, nodejs, npm
- Linux: install lazygit from GitHub releases
- Linux: install Hack Nerd Font to ~/.local/share/fonts