### PR TITLE
Add ~/.local/bin to PATH

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -18,6 +18,9 @@ export LC_CTYPE="${LANGUAGE}"
 export EDITOR=nvim
 export GIT_EDITOR="${EDITOR}"
 
+# PATH
+export PATH="$HOME/.local/bin:$PATH"
+
 # history
 HISTFILE=~/.zsh_history
 HISTSIZE=1000000


### PR DESCRIPTION
## Summary
Added `$HOME/.local/bin` to the PATH environment variable in the zsh configuration to prioritize locally installed binaries.

## Changes
- Added `$HOME/.local/bin` to the beginning of the PATH, ensuring locally installed executables take precedence over system-wide versions
- Placed the PATH export in a dedicated section for better organization and clarity

## Details
This change allows user-installed tools and scripts in `~/.local/bin` to be found and executed without requiring the full path. By prepending this directory to PATH, local binaries will be prioritized over system binaries with the same name, which is useful for managing tool versions and custom scripts.

https://claude.ai/code/session_01D4AYnTK5Ged2kj8q2tyi88