### PR TITLE
chore: chezmoi 設定の整理（settings同期 / git設定のマシン固有分離）

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -3,3 +3,4 @@ README.md
 CLAUDE.md
 raycast
 diagrams
+.config/git/local.gitconfig

--- a/dot_claude/settings.json.tmpl
+++ b/dot_claude/settings.json.tmpl
@@ -21,7 +21,8 @@
     "playwright@claude-plugins-official": true
   },
   "alwaysThinkingEnabled": true,
-  "effortLevel": "high",
+  "effortLevel": "xhigh",
   "skipDangerousModePermissionPrompt": true,
-  "theme": "dark"
+  "theme": "dark",
+  "model": "opus[1m]"
 }

--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -4,3 +4,7 @@
 
 [ghq]
 	root = ~/dev
+
+# マシン固有設定（ローカルにのみ存在）。ファイルが無いマシンでは無視される
+[include]
+	path = ~/.config/git/local.gitconfig


### PR DESCRIPTION
## 概要

`chezmoi diff` で検出されたソースとローカルの乖離を整理。2つの独立した変更を含む（コミット単位で分割済み）。

## 変更内容

### 1. `chore(claude)`: settings をローカル値に同期
`dot_claude/settings.json.tmpl` を現在のローカル値に合わせて更新。
- `effortLevel`: `high` → `xhigh`
- `model`: `opus[1m]` を追加

※ `.tmpl` 拡張子だがテンプレート構文を含まない素の JSON のため `chezmoi re-add` がスキップする。直接編集で対応。

### 2. `feat(git)`: マシン固有の git 設定を分離
特定環境でのみ使う URL 書き換え（専用 SSH 鍵）は**マシン固有**のため、共有リポジトリには載せない。

- 共有 `dot_gitconfig` には `[include] path = ~/.config/git/local.gitconfig` の1行だけを追加
- 実体はリポジトリ管理外の `~/.config/git/local.gitconfig` に分離し、`.chezmoiignore` に登録
- include 先が存在しないマシンでは git が黙って無視するため副作用なし

これにより `chezmoi apply` でローカル固有設定が消える問題を解消しつつ、マシン固有設定がリポジトリに混入しない。

## 確認事項

- [x] `chezmoi apply --force` 後に `chezmoi status` が同期
- [x] ローカル固有設定が `local.gitconfig` 経由で維持されることを検証
- [x] リポジトリのツリー・履歴・差分にマシン固有/組織固有の文字列が含まれないことを確認

## レビュー観点

- マシン固有設定の分離方針（include 方式）でよいか
- `local.gitconfig`（マシン固有設定の実体）はこのマシンにのみ存在し、PR には含まれない